### PR TITLE
Add overlong buffer to PrimeRewardManager

### DIFF
--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -480,6 +480,11 @@ Reward Model
   of computing rule-based reward and handling different reward sources. Default
   is ``naive``. If all verification functions are multiprocessing-safe, the reward
   manager can be set to ``prime`` for parallel verification.
+``reward_model.overlong_buffer``:
+  Configure penalties for slightly overlong outputs. Set ``enable`` to ``True``
+  to activate the penalty, ``len`` to the allowed buffer length, and
+  ``penalty_factor`` to the maximum penalty when the length reaches
+  ``max_response_length + len``.
 
 Customized Reward Function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary
- support overlong_buffer penalty in PrimeRewardManager
- document `reward_model.overlong_buffer` option in config guide

## Testing
- `pre-commit run --files verl/workers/reward_manager/prime.py docs/examples/config.rst`
- ❌ `pytest -q tests/workers/reward_manager/test_registry_on_cpu.py` *(failed: ModuleNotFoundError: No module named 'tensordict')*

------
https://chatgpt.com/codex/tasks/task_e_688acb8060308332ac48f0885d8b65d4